### PR TITLE
pyproject.toml now gets the version from main.py, Fixed cli.py

### DIFF
--- a/OSCR/cli.py
+++ b/OSCR/cli.py
@@ -2,7 +2,7 @@
 
 import argparse
 
-from OSCR import OSCR
+import OSCR
 
 
 def summary(parser):
@@ -21,7 +21,7 @@ def main():
     parser.add_argument("-s", "--summary", action=argparse.BooleanOptionalAction)
     args = parser.parse_args()
 
-    parser = OSCR(args.input)
+    parser = OSCR.OSCR(args.input)
     parser.analyze_log_file()
 
     if args.summary:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "hatchling.build"
 
 [project]
 name = "STO-OSCR"
-version = "2024.02b111"
 dependencies = [
   "numpy"
 ]
@@ -19,6 +18,7 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python"
 ]
+dynamic = ["version"]
 
 [project.optional-dependencies]
 gui = []
@@ -36,3 +36,7 @@ packages = ["OSCR/"]
 
 [project.scripts]
 oscr-cli = "OSCR.cli:main"
+
+[tool.hatch.version]
+path = "OSCR/main.py"
+pattern = "\\s*version = '(?P<version>.*)'"


### PR DESCRIPTION
- pyproject.toml now gets the version from main.py
- cli.py was not importing OSCR correctly when not installed.