### PR TITLE
Added Difficulty Detection and Added Computer (NPC) Overview.

### DIFF
--- a/OSCR/baseparser.py
+++ b/OSCR/baseparser.py
@@ -83,6 +83,10 @@ def analyze_shallow(combat:Combat, settings):
             magnitude = abs(line.magnitude)
             try:
                 target.total_damage_taken += magnitude
+                if line.type == 'Shield':
+                    target.total_shield_damage_taken += magnitude
+                else:
+                    target.total_hull_damage_taken += magnitude
                 target.attacks_in_num += 1
             except AttributeError:
                 pass
@@ -215,10 +219,7 @@ def get_flags(flag_str:str) -> tuple[bool]:
 def identify_difficulty(combat:Combat) -> str:
     '''
     Identify combat based on the hull damage taken of a specific entity.
-    Currently this only works on entities that do not have shields as
-    total_damage_taken counts shield damage.
-
-    margin of error here is +/- 10% as not all damage seems to be recorded.
+    margin of error here is +/- 10% to detect over/underkill
     '''
     hull_identifiers = MAP_DIFFICULTY_ENTITY_HULL_IDENTIFIERS.get(combat.map, None)
     if hull_identifiers:
@@ -226,7 +227,7 @@ def identify_difficulty(combat:Combat) -> str:
             entity_map = hull_identifiers.get(entity.handle, None)
             if entity_map:
                 for diff, damage in entity_map.items():
-                    if damage is not None and damage - entity.total_damage_taken <= entity.total_damage_taken * 0.1:
+                    if damage is not None and abs(damage - entity.total_hull_damage_taken) <= entity.total_hull_damage_taken * 0.1:
                         return diff
 
     return "Normal"

--- a/OSCR/cli.py
+++ b/OSCR/cli.py
@@ -4,15 +4,19 @@ import argparse
 
 import OSCR
 
-
 def summary(parser):
     """Print the combat summary for each combat"""
     for idx, _ in enumerate(parser.analyzed_combats):
         parser.shallow_combat_analysis(idx)
-        print(f"{parser.active_combat.map}")
-        for k, v in parser.active_combat.player_dict.items():
-            print(f"  {v.name}{v.handle}: {v.total_damage:,.0f} ({v.DPS:,.0f} DPS)")
+        print(f"{parser.active_combat.map} - {parser.active_combat.difficulty}")
 
+        print(f"  Players (Damage)")
+        for k, v in parser.active_combat.player_dict.items():
+            print(f"    {v.name}{v.handle}: {v.total_damage:,.0f} ({v.DPS:,.0f} DPS)")
+
+        print(f"  NPCs (Damage Taken)")
+        for k, v in parser.active_combat.computer_dict.items():
+            print(f"    {v.name} - {v.handle}: {v.total_damage_taken:,.0f}")
 
 def main():
     """Main"""

--- a/OSCR/cli.py
+++ b/OSCR/cli.py
@@ -16,7 +16,7 @@ def summary(parser):
 
         print(f"  NPCs (Damage Taken)")
         for k, v in parser.active_combat.computer_dict.items():
-            print(f"    {v.name} - {v.handle}: {v.total_damage_taken:,.0f}")
+            print(f"    {v.name} - {v.handle}: tot={v.total_damage_taken:,.0f} hull={v.total_hull_damage_taken:,.0f} shield={v.total_shield_damage_taken:,.0f}")
 
 def main():
     """Main"""

--- a/OSCR/datamodels.py
+++ b/OSCR/datamodels.py
@@ -38,6 +38,8 @@ PlayerOverviewRow = namedtuple('PlayerOverviewRow',
         'heal_num',
         'crit_num',
         'total_damage_taken',
+        'total_hull_damage_taken',
+        'total_shield_damage_taken',
         'attacks_in_num',
         'total_attacks',
         'hull_attacks',
@@ -65,6 +67,8 @@ ComputerOverviewRow = namedtuple('ComputerOverviewRow',
         'heal_num',
         'crit_num',
         'total_damage_taken',
+        'total_hull_damage_taken',
+        'total_shield_damage_taken',
         'attacks_in_num',
         'total_attacks',
         'hull_attacks',
@@ -135,9 +139,9 @@ class PlayerTableRow():
     __slots__ = ('name', 'handle', 'combat_time', 'DPS', 'total_damage', 'crit_chance', 'max_one_hit', 
             'debuff', 'damage_share', 'taken_damage_share', 'attacks_in_share', 'total_heals', 
             'heal_crit_chance', 'heal_share', 'deaths', 'heal_crit_num', 'heal_num', 'crit_num', 
-            'total_damage_taken', 'attacks_in_num', 'total_attacks', 'hull_attacks', 'resistance_sum', 
-            'misses', 'DMG_graph_data', 'DPS_graph_data', 'graph_time', 'damage_buffer', 'combat_start',
-            'combat_end')
+            'total_damage_taken', 'total_hull_damage_taken', 'total_shield_damage_taken', 'attacks_in_num', 
+            'total_attacks', 'hull_attacks', 'resistance_sum', 'misses', 'DMG_graph_data', 'DPS_graph_data', 
+            'graph_time', 'damage_buffer', 'combat_start', 'combat_end')
     
     def __init__(self, name:str, handle:str):
         self.name: str = name
@@ -160,6 +164,8 @@ class PlayerTableRow():
         self.heal_num: int = 0
         self.crit_num: int = 0
         self.total_damage_taken: float = 0.0
+        self.total_hull_damage_taken: float = 0.0
+        self.total_shield_damage_taken: float = 0.0
         self.attacks_in_num: int = 0
         self.total_attacks: int = 0
         self.hull_attacks: int = 0
@@ -200,11 +206,13 @@ class PlayerTableRow():
             case 16: return self.heal_num
             case 17: return self.crit_num
             case 18: return self.total_damage_taken
-            case 19: return self.attacks_in_num
-            case 20: return self.total_attacks
-            case 21: return self.hull_attacks
-            case 22: return self.resistance_sum
-            case 23: return self.misses
+            case 19: return self.total_hull_damage_taken
+            case 20: return self.total_shield_damage_taken
+            case 21: return self.attacks_in_num
+            case 22: return self.total_attacks
+            case 23: return self.hull_attacks
+            case 24: return self.resistance_sum
+            case 25: return self.misses
             case _: raise StopIteration()
 
 class ComputerTableRow():
@@ -214,9 +222,9 @@ class ComputerTableRow():
     __slots__ = ('name', 'handle', 'combat_time', 'DPS', 'total_damage', 'crit_chance', 'max_one_hit', 
             'debuff', 'damage_share', 'taken_damage_share', 'attacks_in_share', 'total_heals', 
             'heal_crit_chance', 'heal_share', 'deaths', 'heal_crit_num', 'heal_num', 'crit_num', 
-            'total_damage_taken', 'attacks_in_num', 'total_attacks', 'hull_attacks', 'resistance_sum', 
-            'misses', 'DMG_graph_data', 'DPS_graph_data', 'graph_time', 'damage_buffer', 'combat_start',
-            'combat_end')
+            'total_damage_taken', 'total_hull_damage_taken', 'total_shield_damage_taken', 'attacks_in_num', 
+            'total_attacks', 'hull_attacks', 'resistance_sum', 'misses', 'DMG_graph_data', 'DPS_graph_data', 
+            'graph_time', 'damage_buffer', 'combat_start', 'combat_end')
     
     def __init__(self, handle:str, name:str):
         self.name: str = name
@@ -239,6 +247,8 @@ class ComputerTableRow():
         self.heal_num: int = 0
         self.crit_num: int = 0
         self.total_damage_taken: float = 0.0
+        self.total_hull_damage_taken: float = 0.0
+        self.total_shield_damage_taken: float = 0.0
         self.attacks_in_num: int = 0
         self.total_attacks: int = 0
         self.hull_attacks: int = 0
@@ -279,11 +289,13 @@ class ComputerTableRow():
             case 16: return self.heal_num
             case 17: return self.crit_num
             case 18: return self.total_damage_taken
-            case 19: return self.attacks_in_num
-            case 20: return self.total_attacks
-            case 21: return self.hull_attacks
-            case 22: return self.resistance_sum
-            case 23: return self.misses
+            case 19: return self.total_hull_damage_taken
+            case 20: return self.total_shield_damage_taken
+            case 21: return self.attacks_in_num
+            case 22: return self.total_attacks
+            case 23: return self.hull_attacks
+            case 24: return self.resistance_sum
+            case 25: return self.misses
             case _: raise StopIteration()
 
 

--- a/OSCR/datamodels.py
+++ b/OSCR/datamodels.py
@@ -21,20 +21,57 @@ LogLine = namedtuple('LogLine',
 PlayerOverviewRow = namedtuple('PlayerOverviewRow',
         ('name',
         'handle',
-        'combat_time', 
-        'DPS', 
-        'total_damage', 
-        'crit_chance', 
-        'max_one_hit', 
-        'debuff', 
-        'damage_share', 
-        'taken_damage_share', 
-        'attacks_in_share', 
-        'total_heals', 
-        'heal_crit_chance', 
-        'heal_share', 
-        'deaths'
+        'combat_time',
+        'DPS',
+        'total_damage',
+        'crit_chance',
+        'max_one_hit',
+        'debuff',
+        'damage_share',
+        'taken_damage_share',
+        'attacks_in_share',
+        'total_heals',
+        'heal_crit_chance',
+        'heal_share',
+        'deaths',
+        'heal_crit_num',
+        'heal_num',
+        'crit_num',
+        'total_damage_taken',
+        'attacks_in_num',
+        'total_attacks',
+        'hull_attacks',
+        'resistance_sum',
+        'misses'
         ))
+
+ComputerOverviewRow = namedtuple('ComputerOverviewRow',
+        ('name',
+        'handle',
+        'combat_time',
+        'DPS',
+        'total_damage',
+        'crit_chance',
+        'max_one_hit',
+        'debuff',
+        'damage_share',
+        'taken_damage_share',
+        'attacks_in_share',
+        'total_heals',
+        'heal_crit_chance',
+        'heal_share',
+        'deaths',
+        'heal_crit_num',
+        'heal_num',
+        'crit_num',
+        'total_damage_taken',
+        'attacks_in_num',
+        'total_attacks',
+        'hull_attacks',
+        'resistance_sum',
+        'misses'
+        ))
+
 
 class TreeModel():
     """
@@ -159,7 +196,96 @@ class PlayerTableRow():
             case 12: return self.heal_crit_chance
             case 13: return self.heal_share
             case 14: return self.deaths
+            case 15: return self.heal_crit_num
+            case 16: return self.heal_num
+            case 17: return self.crit_num
+            case 18: return self.total_damage_taken
+            case 19: return self.attacks_in_num
+            case 20: return self.total_attacks
+            case 21: return self.hull_attacks
+            case 22: return self.resistance_sum
+            case 23: return self.misses
             case _: raise StopIteration()
+
+class ComputerTableRow():
+    '''
+    Contains a single row of data
+    '''
+    __slots__ = ('name', 'handle', 'combat_time', 'DPS', 'total_damage', 'crit_chance', 'max_one_hit', 
+            'debuff', 'damage_share', 'taken_damage_share', 'attacks_in_share', 'total_heals', 
+            'heal_crit_chance', 'heal_share', 'deaths', 'heal_crit_num', 'heal_num', 'crit_num', 
+            'total_damage_taken', 'attacks_in_num', 'total_attacks', 'hull_attacks', 'resistance_sum', 
+            'misses', 'DMG_graph_data', 'DPS_graph_data', 'graph_time', 'damage_buffer', 'combat_start',
+            'combat_end')
+    
+    def __init__(self, handle:str, name:str):
+        self.name: str = name
+        self.handle: str = handle
+        self.combat_time: float = 0.0
+        self.DPS: float = 0.0
+        self.total_damage: float = 0.0
+        self.crit_chance: float = 0.0
+        self.max_one_hit: float = 0.0
+        self.debuff: float = 0.0
+        self.damage_share: float = 0.0
+        self.taken_damage_share: float = 0.0
+        self.attacks_in_share: float = 0.0
+        self.total_heals: float = 0.0
+        self.heal_crit_chance: float = 0.0
+        self.heal_share: float = 0.0
+        self.deaths: int = 0
+
+        self.heal_crit_num: int = 0
+        self.heal_num: int = 0
+        self.crit_num: int = 0
+        self.total_damage_taken: float = 0.0
+        self.attacks_in_num: int = 0
+        self.total_attacks: int = 0
+        self.hull_attacks: int = 0
+        self.resistance_sum: float = 0.0
+        self.misses: int = 0
+
+        self.DMG_graph_data: list[float] = list()
+        self.DPS_graph_data: list[float] = list()
+        self.graph_time: list[float] = list()
+        self.damage_buffer: float = 0.0
+        self.combat_start: datetime = None
+        self.combat_end: datetime = None
+
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__}: {self.name}{self.handle}>'
+    
+    def __len__(self) -> int:
+        return 15
+    
+    def __getitem__(self, position):
+        match position:
+            case 0: return self.name
+            case 1: return self.handle
+            case 2: return self.combat_time
+            case 3: return self.DPS
+            case 4: return self.total_damage
+            case 5: return self.crit_chance
+            case 6: return self.max_one_hit
+            case 7: return self.debuff
+            case 8: return self.damage_share
+            case 9: return self.taken_damage_share
+            case 10: return self.attacks_in_share
+            case 11: return self.total_heals
+            case 12: return self.heal_crit_chance
+            case 13: return self.heal_share
+            case 14: return self.deaths
+            case 15: return self.heal_crit_num
+            case 16: return self.heal_num
+            case 17: return self.crit_num
+            case 18: return self.total_damage_taken
+            case 19: return self.attacks_in_num
+            case 20: return self.total_attacks
+            case 21: return self.hull_attacks
+            case 22: return self.resistance_sum
+            case 23: return self.misses
+            case _: raise StopIteration()
+
 
 class TableRow():
     '''
@@ -206,20 +332,30 @@ class Combat():
     '''
     Contains a single combat including raw log lines, map and combat information and shallow parse results.
     '''
-    __slots__ = ('log_data', '_map', 'date_time', 'table', 'graph_data')
+    __slots__ = ('log_data', '_map', '_difficulty', 'date_time', 'table', 'graph_data', 'computer_table', 'computer_graph_data')
 
     def __init__(self, log_lines:Optional[list[LogLine]] = None) -> None:
         self.log_data = log_lines
         self._map = None
+        self._difficulty = None
         self.date_time = None
         self.table = None
         self.graph_data = None
+        self.computer_table = None
+        self.computer_graph_data = None
 
     @property
     def player_dict(self):
         dictionary = dict()
         for player_row in self.table:
             dictionary[f'{player_row[0]}{player_row[1]}'] = PlayerOverviewRow(*player_row)
+        return dictionary
+
+    @property
+    def computer_dict(self):
+        dictionary = dict()
+        for computer_row in self.computer_table:
+            dictionary[f'{computer_row[0]}{computer_row[1]}'] = ComputerOverviewRow(*computer_row)
         return dictionary
 
     @property
@@ -232,8 +368,18 @@ class Combat():
     def map(self, map_name):
         self._map = map_name
 
+    @property
+    def difficulty(self) -> str:
+        if self._difficulty is None:
+            return 'Normal'
+        return self._difficulty
+    
+    @difficulty.setter
+    def difficulty(self, difficulty_name):
+        self._difficulty = difficulty_name
+
     def __repr__(self) -> str:
-        return f'<{self.__class__.__name__} - Map: {self.map} - Datetime: {self.date_time}>'
+        return f'<{self.__class__.__name__} - Map: {self.map} - Difficulty: {self.difficulty} - Datetime: {self.date_time}>'
     
     def __gt__(self, other):
         if not isinstance(other, Combat):

--- a/OSCR/iofunc.py
+++ b/OSCR/iofunc.py
@@ -46,7 +46,7 @@ MAP_DIFFICULTY_ENTITY_HULL_IDENTIFIERS = {
     },
     "Hive_Space": {
         "Borg Queen Octahedron": {
-            "Elite": 0,
+            "Elite": 16040000, # TODO: Need to validate.
             "Advanced": 3414068,
         },
     },

--- a/OSCR/iofunc.py
+++ b/OSCR/iofunc.py
@@ -7,7 +7,6 @@ from .utilities import to_datetime, logline_to_str
 
 # currently as constant, will be some kind of import from disk or config file eventually
 MAP_IDENTIFIERS_EXISTENCE = {
-    "Space_Borg_Battleship_Raidisode_Sibrian_Elite_Initial": "Infected_Space_Elite",
     "Space_Borg_Dreadnought_Raidisode_Sibrian_Final_Boss": "Infected_Space",
     "Mission_Space_Romulan_Colony_Flagship_Lleiset": "Azure_Nebula",
     "Space_Klingon_Dreadnought_Dsc_Sarcophagus": "Battle_At_The_Binary_Stars",
@@ -32,6 +31,15 @@ MAP_IDENTIFIERS_EXISTENCE = {
     "Msn_Kcw_Rura_Penthe_System_Tfo_Dilithium_Hauler": "Best_Served_Cold",
     "Ground_Federation_Capt_Mirror_Runabout_Tfo": "Operation_Wolf"
     }
+
+MAP_DIFFICULTY_ENTITY_HULL_IDENTIFIERS = {
+    "Infected_Space": {
+        "Gateway": {
+            "Elite": 32000000,
+            "Advanced": 7200000,
+        },
+    },
+}
 
 def format_timestamp(timestamp:str) -> str:
     '''

--- a/OSCR/iofunc.py
+++ b/OSCR/iofunc.py
@@ -60,8 +60,8 @@ MAP_DIFFICULTY_ENTITY_HULL_IDENTIFIERS = {
     },
     # TODO: Capture Na'kuhl Captain Hull Value (There's only one)
     "Miner_Instabilities": {
-        "Na'kuhl Commander": {
-            "Elite": 6513,
+        "Na'kuhl Captain": {
+            "Elite": 20843,
         },
     },
 }

--- a/OSCR/iofunc.py
+++ b/OSCR/iofunc.py
@@ -29,14 +29,39 @@ MAP_IDENTIFIERS_EXISTENCE = {
     "Space_Borg_Dreadnought_Hive_Intro": "Hive_Space",
     "Mission_Space_Borg_Battleship_Queen_1_0f_2": "Hive_Space",
     "Msn_Kcw_Rura_Penthe_System_Tfo_Dilithium_Hauler": "Best_Served_Cold",
-    "Ground_Federation_Capt_Mirror_Runabout_Tfo": "Operation_Wolf"
+    "Ground_Federation_Capt_Mirror_Runabout_Tfo": "Operation_Wolf",
+    "Bluegills_Ground_Boss": "Bug_Hunt",
+    "Msn_Edren_Queue_Ground_Gorn_Lt_Tos_Range_Rock": "Miner_Instabilities",
     }
 
+# There's a possibility where there's so much overkill that the entity is
+# detected as an entity of the difficulty higher. This would be more likely to
+# happen on ground maps.
 MAP_DIFFICULTY_ENTITY_HULL_IDENTIFIERS = {
     "Infected_Space": {
         "Gateway": {
             "Elite": 32000000,
-            "Advanced": 7200000,
+            "Advanced": 6828137,
+        },
+    },
+    "Hive_Space": {
+        "Borg Queen Octahedron": {
+            "Elite": 32000000,
+            "Advanced": 3414068,
+        },
+    },
+    "Bug_Hunt": {
+        "Larval Queen": {
+            "Elite": 32567,
+        },
+        "Spawnmother": {
+            "Elite": 449432,
+        },
+    },
+    # TODO: Capture Na'kuhl Captain Hull Value (There's only one)
+    "Miner_Instabilities": {
+        "Na'kuhl Commander": {
+            "Elite": 6513,
         },
     },
 }

--- a/OSCR/iofunc.py
+++ b/OSCR/iofunc.py
@@ -46,7 +46,7 @@ MAP_DIFFICULTY_ENTITY_HULL_IDENTIFIERS = {
     },
     "Hive_Space": {
         "Borg Queen Octahedron": {
-            "Elite": 32000000,
+            "Elite": 0,
             "Advanced": 3414068,
         },
     },

--- a/OSCR/main.py
+++ b/OSCR/main.py
@@ -12,7 +12,7 @@ TABLE_HEADER = ('Combat Time', 'DPS', 'Total Damage', 'Crit Chance', 'Max One Hi
 
 class OSCR():
 
-    version = '2024.02b111'
+    version = '2024.02b112'
 
     def __init__(self, log_path:str = None, settings:dict = None):
         self.log_path = log_path

--- a/OSCR/main.py
+++ b/OSCR/main.py
@@ -144,10 +144,10 @@ class OSCR():
                 if current_map is not None:
                     current_combat.map = current_map
                     map_identified = True
-   
+
             last_log_time = log_time
             current_combat_lines.append(current_line)
-    
+
         current_combat_lines.reverse()
         current_combat.log_data = current_combat_lines
         current_combat.date_time = last_log_time


### PR DESCRIPTION
- I assumed C = Computer like P = Player so I called them the Computer Overview. NPC might have been better maybe?
- Broke damage taken down into hull damage taken and shield damage taken. This is important for the simple difficulty detection method I included in this PR.
- Added Bug Hunt and Miner Instabilities to the map detection list.
- Added a new way to detect difficulty that works on more maps than just ISE. AFAIK none of the newer combat parsers have gone down this path (I Know SCM used to have support for this, iirc it even had anti-juice support). Detection now works for ISE, ISA, HSE, HSA, MIE, and BHE. Those were the only maps that came to mind to test tonight. Other maps just require 1 or more enemies with known HP values that can't easily be over killed (current detection is +/- 10%). Overkill could potentially case poor detections on ground maps or maps where enemies have very similar life pools between difficulties.

Other Note: I don't think that Player and Computer Overviews need two separate arguments, and I don't like how I did entity detection for C[] entities (I am using their entity id (I think that's what its called). I'd preferably want the identifier (e.g. `Space_Borg_Dreadnought_Raidisode_Sibrian_Final_Boss`) somewhere in this object but it's really not necessary when name is good enough for the DPS detection.

Sorry lots of words, but likely won't put much work in during the week. Wanted to get this done tonight.