### PR TITLE
Difficulty detection adjustments + Added Jupiter Station Showdown / Operation Wolf

### DIFF
--- a/OSCR/baseparser.py
+++ b/OSCR/baseparser.py
@@ -192,8 +192,8 @@ def identify_difficulty(combat: Combat, computer_dict: dict) -> str:
 
     difficulty = "Unknown"
 
-    hull_identifiers = MAP_DIFFICULTY_ENTITY_HULL_IDENTIFIERS.get(combat.map, None)
-    if hull_identifiers:
+    hull_identifiers = MAP_DIFFICULTY_ENTITY_HULL_IDENTIFIERS.get(combat.map, {})
+    if len(hull_identifiers):
         for _, entity in computer_dict.items():
             entity_map = hull_identifiers.get(entity.name, None)
             if entity_map:
@@ -202,5 +202,10 @@ def identify_difficulty(combat: Combat, computer_dict: dict) -> str:
                             entity.total_hull_damage_taken * 0.1:
                         difficulty = diff
                         break
+    else:
+        # A map has been detected but no difficulty mapping has been provided.
+        # This is applicable for maps with only 1 difficulty (e.g. Operation Wolf)
+        difficulty = "Normal"
+
 
     return difficulty

--- a/OSCR/baseparser.py
+++ b/OSCR/baseparser.py
@@ -192,7 +192,10 @@ def identify_difficulty(combat: Combat, computer_dict: dict) -> str:
 
     difficulty = "Unknown"
 
-    hull_identifiers = MAP_DIFFICULTY_ENTITY_HULL_IDENTIFIERS.get(combat.map, {})
+    hull_identifiers = MAP_DIFFICULTY_ENTITY_HULL_IDENTIFIERS.get(combat.map, None)
+    if hull_identifiers is None:
+        return difficulty
+
     if len(hull_identifiers):
         for _, entity in computer_dict.items():
             entity_map = hull_identifiers.get(entity.name, None)

--- a/OSCR/iofunc.py
+++ b/OSCR/iofunc.py
@@ -32,10 +32,11 @@ MAP_IDENTIFIERS_EXISTENCE = {
     "Space_Borg_Dreadnought_Hive_Intro": ("Hive Space", ''),
     "Mission_Space_Borg_Battleship_Queen_1_0f_2": ("Hive Space", ''),
     "Msn_Kcw_Rura_Penthe_System_Tfo_Dilithium_Hauler": ("Best Served Cold", ''),
-    "Ground_Federation_Capt_Mirror_Runabout_Tfo": ("Operation Wolf", ''),
+    "Ground_Federation_Capt_Mirror_Runabout_Tfo": ("Operation Wolf", 'Normal'),
     "Bluegills_Ground_Boss": ("Bug Hunt", ''),
     "Msn_Edren_Queue_Ground_Gorn_Lt_Tos_Range_Rock": ("Miner Instabilities", ''),
-    }
+    "Msn_Ground_Capt_Mirror_Janeway_Boss_Unkillable": ("Jupiter Station Showdown", ''),
+}
 
 # There's a possibility where there's so much overkill that the entity is
 # detected as an entity of the difficulty higher. This would be more likely to
@@ -61,12 +62,21 @@ MAP_DIFFICULTY_ENTITY_HULL_IDENTIFIERS = {
             "Elite": 449432,
         },
     },
-    # TODO: Capture Na'kuhl Captain Hull Value (There's only one)
+    # TODO: Capture Na'kuhl Captain Health Value (There's only one)
     "Miner Instabilities": {
         "Na'kuhl Captain": {
             "Elite": 20843,
         },
     },
+    # NOTE: Janeway is unkillable - this is approximately how much damage she takes.
+    # Actual Health: 83373
+    "Jupiter Station Showdown": {
+        "Marshal Janeway": {
+            "Elite": 63000,
+        },
+    },
+    "Operation Wolf": {
+    }
 }
 
 def format_timestamp(timestamp:str) -> str:

--- a/OSCR/main.py
+++ b/OSCR/main.py
@@ -10,7 +10,7 @@ from .parser import analyze_combat
 
 class OSCR():
 
-    version = '2024.02b221'
+    version = '2024.02b250'
 
     def __init__(self, log_path:str = None, settings:dict = None):
         self.log_path = log_path


### PR DESCRIPTION
- Difficulty detection will now properly detect Normal Mode for events defined to have no hull identifiers (but an entry in the hull identifiers map)
- Added Jupiter Station Showdown (Elite)
- Added Operation Wolf. 